### PR TITLE
Fix HuntHttpService singleton initialization HuntHttpService.java

### DIFF
--- a/app/src/main/java/com/geeksville/mesh/service/HuntHttpService.java
+++ b/app/src/main/java/com/geeksville/mesh/service/HuntHttpService.java
@@ -34,9 +34,16 @@ public class HuntHttpService {
 
     private HuntHttpService(){}
 
-    public static synchronized HuntHttpService getInstance(){
-        if(instance.get() == null)
-            return new HuntHttpService();
+    public static HuntHttpService getInstance(){
+        HuntHttpService currentInstance = instance.get();
+        if (currentInstance != null) {
+            return currentInstance;
+        }
+
+        HuntHttpService newInstance = new HuntHttpService();
+        if (instance.compareAndSet(null, newInstance)) {
+            return newInstance;
+        }
 
         return instance.get();
     }


### PR DESCRIPTION
getInstance() now stores the created instance (CAS) so repeated calls return the same service. Prevents creating multiple OkHttpClient instances and separates state.
