### PR TITLE
Add Neighbor Discovery workflow and improve relay telemetry visibility

### DIFF
--- a/app/src/main/aidl/com/geeksville/mesh/IMeshService.aidl
+++ b/app/src/main/aidl/com/geeksville/mesh/IMeshService.aidl
@@ -127,6 +127,9 @@ interface IMeshService {
     /// Send traceroute packet with wantResponse to nodeNum
     void requestTraceroute(in int requestId, in int destNum);
 
+    /// Send neighbor discovery packet with wantResponse to nodeNum
+    void requestNeighborInfo(in int requestId, in int destNum);
+
     /// Send Shutdown admin packet to nodeNum
     void requestShutdown(in int requestId, in int destNum);
 

--- a/app/src/main/java/com/geeksville/mesh/MainActivity.kt
+++ b/app/src/main/java/com/geeksville/mesh/MainActivity.kt
@@ -40,6 +40,7 @@ import android.widget.ArrayAdapter
 import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.LinearLayout
+import android.widget.ScrollView
 import android.widget.Spinner
 import android.widget.TextView
 import android.widget.Toast
@@ -86,11 +87,14 @@ import com.geeksville.mesh.database.DbImportState
 import com.geeksville.mesh.model.BluetoothViewModel
 import com.geeksville.mesh.model.Contact
 import com.geeksville.mesh.model.DeviceVersion
+import com.geeksville.mesh.model.NeighborDiscoveryResult
 import com.geeksville.mesh.model.Node
 import com.geeksville.mesh.model.RadioConfigViewModel
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.model.UIViewModel.Companion.getPreferences
 import com.geeksville.mesh.model.colorizeTracerouteResponse
+import com.geeksville.mesh.model.formatNeighborDiscoverySnr
+import com.geeksville.mesh.model.neighborDiscoverySnrColor
 import com.geeksville.mesh.prefs.UserPrefs
 import com.geeksville.mesh.prefs.UserPrefs.Hunting.BACKGROUND_HUNT
 import com.geeksville.mesh.prefs.UserPrefs.Hunting.HUNT_MODE
@@ -739,6 +743,49 @@ class MainActivity : AppCompatActivity(), Logging {
             )
 
             model.clearTracerouteResponse()
+        }
+
+        model.neighborDiscoveryResponse.observe(this) { discovery ->
+
+            if (discovery == null) return@observe
+
+            val storedDiscovery = discovery
+
+            val dialog = MaterialAlertDialogBuilder(this)
+                .setCancelable(false)
+                .setView(buildNeighborDiscoveryDialogView(storedDiscovery))
+                .setNegativeButton(R.string.view_on_map) { _, _ ->
+
+                    model.neighborDiscoveryMapAvailability(storedDiscovery)?.let {
+                        model.showNeighborDiscoveryMap(it)
+                    } ?: run {
+                        val gpsDialog = MaterialAlertDialogBuilder(this)
+                            .setCancelable(false)
+                            .setMessage(R.string.neighbor_discovery_request_gps_prompt)
+                            .setNegativeButton(android.R.string.no) { _, _ -> }
+                            .setPositiveButton(android.R.string.yes) { _, _ ->
+                                model.requestNeighborDiscoveryPositions(storedDiscovery)
+                            }
+                            .show()
+
+                        setDialogButtonsColor(
+                            gpsDialog,
+                            AlertDialog.BUTTON_NEGATIVE,
+                            AlertDialog.BUTTON_POSITIVE,
+                        )
+                    }
+
+                }
+                .setPositiveButton(R.string.okay) { _, _ -> }
+                .show()
+
+            setDialogButtonsColor(
+                dialog,
+                AlertDialog.BUTTON_NEGATIVE,
+                AlertDialog.BUTTON_POSITIVE,
+            )
+
+            model.clearNeighborDiscoveryResponse()
         }
 
         try {
@@ -1527,6 +1574,81 @@ class MainActivity : AppCompatActivity(), Logging {
             badge.isVisible = true
         } else {
             tab.removeBadge()
+        }
+    }
+
+    private fun buildNeighborDiscoveryDialogView(discovery: NeighborDiscoveryResult): View {
+        val density = resources.displayMetrics.density
+        val outerPadding = (24 * density).toInt()
+        val rowPadding = (8 * density).toInt()
+
+        val rows = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+        }
+
+        if (discovery.discovered.isEmpty()) {
+            rows.addView(
+                TextView(this).apply {
+                    text = getString(R.string.neighbor_discovery_no_neighbors)
+                    gravity = Gravity.CENTER_HORIZONTAL
+                }
+            )
+        } else {
+            discovery.discovered.forEach { link ->
+                rows.addView(
+                    LinearLayout(this).apply {
+                        orientation = LinearLayout.HORIZONTAL
+                        setPadding(0, rowPadding, 0, rowPadding)
+
+                        addView(
+                            TextView(this@MainActivity).apply {
+                                text = link.node.longName
+                                layoutParams = LinearLayout.LayoutParams(
+                                    0,
+                                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                                    1f,
+                                )
+                            }
+                        )
+
+                        addView(
+                            TextView(this@MainActivity).apply {
+                                text = formatNeighborDiscoverySnr(link.snr)
+                                gravity = Gravity.END
+                                setTextColor(neighborDiscoverySnrColor(link.snr))
+                            }
+                        )
+                    }
+                )
+            }
+        }
+
+        return LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(outerPadding, outerPadding, outerPadding, outerPadding / 2)
+
+            addView(
+                TextView(this@MainActivity).apply {
+                    text = getString(R.string.neighbor_discovery)
+                    gravity = Gravity.CENTER_HORIZONTAL
+                    textSize = 20f
+                }
+            )
+
+            addView(
+                TextView(this@MainActivity).apply {
+                    text = discovery.origin.longName
+                    gravity = Gravity.CENTER_HORIZONTAL
+                    textSize = 16f
+                    setPadding(0, rowPadding, 0, outerPadding / 2)
+                }
+            )
+
+            addView(
+                ScrollView(this@MainActivity).apply {
+                    addView(rows)
+                }
+            )
         }
     }
 

--- a/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/MetricsViewModel.kt
@@ -77,6 +77,8 @@ data class MetricsState(
     val signalMetrics: List<MeshPacket> = emptyList(),
     val tracerouteRequests: List<MeshLog> = emptyList(),
     val tracerouteResults: List<MeshPacket> = emptyList(),
+    val neighborDiscoveryRequests: List<MeshLog> = emptyList(),
+    val neighborDiscoveryResults: List<MeshPacket> = emptyList(),
     val positionLogs: List<Position> = emptyList(),
     val deviceHardware: DeviceHardware? = null,
 ) {
@@ -84,6 +86,7 @@ data class MetricsState(
     fun hasEnvironmentMetrics() = environmentMetrics.isNotEmpty()
     fun hasSignalMetrics() = signalMetrics.isNotEmpty()
     fun hasTracerouteLogs() = tracerouteRequests.isNotEmpty()
+    fun hasNeighborDiscoveryLogs() = neighborDiscoveryRequests.isNotEmpty()
     fun hasPositionLogs() = positionLogs.isNotEmpty()
 
     fun deviceMetricsFiltered(timeFrame: TimeFrame): List<TelemetryProtos.Telemetry> {
@@ -198,7 +201,12 @@ class MetricsViewModel @Inject constructor(
         hasDecoded() && decoded.wantResponse && from == 0 && to == destNum
     }
 
+    private fun MeshLog.hasValidNeighborDiscovery(): Boolean = with(fromRadio.packet) {
+        hasDecoded() && decoded.wantResponse && from == 0 && to == destNum
+    }
+
     fun getUser(nodeNum: Int) = radioConfigRepository.getUser(nodeNum)
+    fun getNode(nodeNum: Int) = radioConfigRepository.nodeDBbyNum.value[nodeNum]
     val tileSource get() = CustomTileSource.getTileSource(preferences.getInt(MAP_STYLE_ID, 0))
 
     fun deleteLog(uuid: String) = viewModelScope.launch(dispatchers.io) {
@@ -267,6 +275,18 @@ class MetricsViewModel @Inject constructor(
                 state.copy(
                     tracerouteRequests = request.filter { it.hasValidTraceroute() },
                     tracerouteResults = response,
+                )
+            }
+        }.launchIn(viewModelScope)
+
+        combine(
+            meshLogRepository.getLogsFrom(nodeNum = 0, PortNum.NEIGHBORINFO_APP_VALUE),
+            meshLogRepository.getMeshPacketsFrom(destNum, PortNum.NEIGHBORINFO_APP_VALUE),
+        ) { request, response ->
+            _state.update { state ->
+                state.copy(
+                    neighborDiscoveryRequests = request.filter { it.hasValidNeighborDiscovery() },
+                    neighborDiscoveryResults = response,
                 )
             }
         }.launchIn(viewModelScope)

--- a/app/src/main/java/com/geeksville/mesh/model/NeighborDiscovery.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/NeighborDiscovery.kt
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.geeksville.mesh.model
+
+import android.graphics.Color
+import com.geeksville.mesh.DataPacket
+import com.geeksville.mesh.database.NodeRepository
+import com.geeksville.mesh.database.entity.NodeRegistry
+import org.meshtastic.proto.MeshProtos
+import org.meshtastic.proto.Portnums
+import java.util.Locale
+
+data class NeighborDiscoveryNode(
+    val nodeNum: Int,
+    val userId: String,
+    val longName: String,
+    val shortName: String,
+)
+
+data class NeighborDiscoveryLink(
+    val node: NeighborDiscoveryNode,
+    val snr: Float,
+)
+
+data class NeighborDiscoveryResult(
+    val origin: NeighborDiscoveryNode,
+    val discovered: List<NeighborDiscoveryLink>,
+)
+
+data class NeighborDiscoveryMapLink(
+    val origin: Node,
+    val discovered: Node,
+    val snr: Float,
+)
+
+data class NeighborDiscoveryMap(
+    val origin: Node,
+    val discovered: List<Node>,
+    val links: List<NeighborDiscoveryMapLink>,
+    val source: NeighborDiscoveryResult,
+)
+
+val MeshProtos.MeshPacket.fullNeighborInfo: MeshProtos.NeighborInfo?
+    get() = with(decoded) {
+        if (hasDecoded() && !wantResponse && portnum == Portnums.PortNum.NEIGHBORINFO_APP) {
+            runCatching { MeshProtos.NeighborInfo.parseFrom(payload) }.getOrNull()
+        } else {
+            null
+        }
+    }
+
+fun MeshProtos.MeshPacket.getNeighborDiscoveryResult(
+    getUser: (nodeNum: Int) -> MeshProtos.User?,
+): NeighborDiscoveryResult? = fullNeighborInfo?.let { info ->
+    val originNum = info.nodeId.takeIf { it != 0 } ?: from
+    NeighborDiscoveryResult(
+        origin = resolveNeighborDiscoveryNode(originNum, getUser),
+        discovered = info.neighborsList
+            .filter { it.nodeId != 0 && it.nodeId != originNum }
+            .map { neighbor ->
+                NeighborDiscoveryLink(
+                    node = resolveNeighborDiscoveryNode(neighbor.nodeId, getUser),
+                    snr = neighbor.snr,
+                )
+            }
+            .distinctBy { it.node.nodeNum }
+            .sortedByDescending { it.snr }
+    )
+}
+
+fun evaluateNeighborDiscoveryMapAvailability(
+    discovery: NeighborDiscoveryResult?,
+    nodeDb: NodeRepository,
+    nodeRegistryMap: Map<String, NodeRegistry>,
+): NeighborDiscoveryMap? {
+    val source = discovery ?: return null
+    val origin = resolveNodeForNeighborMap(source.origin, nodeDb, nodeRegistryMap) ?: return null
+    if (!origin.hasNeighborMapPosition()) return null
+
+    val links = source.discovered.mapNotNull { link ->
+        val discovered = resolveNodeForNeighborMap(link.node, nodeDb, nodeRegistryMap)
+            ?: return@mapNotNull null
+        if (!discovered.hasNeighborMapPosition()) return@mapNotNull null
+
+        NeighborDiscoveryMapLink(
+            origin = origin,
+            discovered = discovered,
+            snr = link.snr,
+        )
+    }.distinctBy { it.discovered.num }
+
+    if (links.isEmpty()) return null
+
+    return NeighborDiscoveryMap(
+        origin = origin,
+        discovered = links.map { it.discovered },
+        links = links,
+        source = source,
+    )
+}
+
+fun neighborDiscoverySnrColor(snr: Float?): Int = when {
+    snr == null -> Color.GRAY
+    snr >= SNR_GOOD_THRESHOLD -> Color.GREEN
+    snr >= SNR_FAIR_THRESHOLD -> Color.rgb(255, 230, 0)
+    else -> Color.rgb(247, 147, 26)
+}
+
+fun formatNeighborDiscoverySnr(snr: Float?): String = when (snr) {
+    null -> "? dB"
+    else -> String.format(Locale.US, "%.1f dB", snr)
+}
+
+private fun resolveNeighborDiscoveryNode(
+    nodeNum: Int,
+    getUser: (nodeNum: Int) -> MeshProtos.User?,
+): NeighborDiscoveryNode {
+    val fallbackId = DataPacket.nodeNumToDefaultId(nodeNum)
+    val user = getUser(nodeNum)
+    val shortName = user?.shortName?.takeIf { it.isNotBlank() } ?: fallbackId.takeLast(4)
+    val longName = user?.longName?.takeIf { it.isNotBlank() } ?: "Meshtastic ${fallbackId.takeLast(4)}"
+
+    return NeighborDiscoveryNode(
+        nodeNum = nodeNum,
+        userId = user?.id?.takeIf { it.isNotBlank() } ?: fallbackId,
+        longName = longName,
+        shortName = shortName,
+    )
+}
+
+private fun resolveNodeForNeighborMap(
+    node: NeighborDiscoveryNode,
+    nodeDb: NodeRepository,
+    nodeRegistryMap: Map<String, NodeRegistry>,
+): Node? {
+    nodeDb.nodeDBbyNum.value[node.nodeNum]?.let { knownNode ->
+        if (knownNode.hasNeighborMapPosition()) return knownNode
+    }
+
+    val registryNode = nodeRegistryMap[node.userId] ?: return null
+    val latitudeI = registryNode.latitudeI ?: return null
+    val longitudeI = registryNode.longitudeI ?: return null
+    val defaultName = registryNode.defaultName ?: "Meshtastic ${node.userId.takeLast(4)}"
+
+    return Node(
+        num = registryNode.nodeNum ?: node.nodeNum,
+        liteNodeId = registryNode.nodeId,
+        liteDefaultName = defaultName,
+        liteLongName = registryNode.longName ?: node.longName,
+        liteShortName = registryNode.shortName ?: node.shortName,
+        liteLatitude = latitudeI * 1e-7,
+        liteLongitude = longitudeI * 1e-7,
+    )
+}
+
+private fun Node.hasNeighborMapPosition(): Boolean = validPosition != null || validLiteNode

--- a/app/src/main/java/com/geeksville/mesh/model/RouteDiscovery.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/RouteDiscovery.kt
@@ -64,6 +64,7 @@ data class TraceRouteMap(
 sealed class MapMode {
     data object Normal : MapMode()
     data class Traceroute(val trace: TraceRouteMap) : MapMode()
+    data class NeighborDiscovery(val discovery: NeighborDiscoveryMap) : MapMode()
 }
 
 @Suppress("MagicNumber")

--- a/app/src/main/java/com/geeksville/mesh/model/UIState.kt
+++ b/app/src/main/java/com/geeksville/mesh/model/UIState.kt
@@ -297,9 +297,15 @@ class UIViewModel @Inject constructor(
 
     private val _mapMode = MutableStateFlow<MapMode>(MapMode.Normal)
     val mapMode = _mapMode.asStateFlow()
+    private val pendingNeighborDiscoveryGpsRecovery = MutableStateFlow<NeighborDiscoveryResult?>(null)
 
     fun showTracerouteMap(trace: TraceRouteMap) {
         _mapMode.value = MapMode.Traceroute(trace)
+        setCurrentTab(2)
+    }
+
+    fun showNeighborDiscoveryMap(discovery: NeighborDiscoveryMap) {
+        _mapMode.value = MapMode.NeighborDiscovery(discovery)
         setCurrentTab(2)
     }
 
@@ -307,8 +313,16 @@ class UIViewModel @Inject constructor(
         _mapMode.value = MapMode.Normal
     }
 
+    fun exitNeighborDiscoveryMode() {
+        _mapMode.value = MapMode.Normal
+    }
+
     fun tracerouteMapAvailability(traceroute: String?) : TraceRouteMap? {
         return evaluateTracerouteMapAvailability(traceroute, nodeDB, nodeRegistryMap.value)
+    }
+
+    fun neighborDiscoveryMapAvailability(discovery: NeighborDiscoveryResult?) : NeighborDiscoveryMap? {
+        return evaluateNeighborDiscoveryMapAvailability(discovery, nodeDB, nodeRegistryMap.value)
     }
 
     fun filterForNode(node: Node?, longName: String?) {
@@ -409,6 +423,19 @@ class UIViewModel @Inject constructor(
             _snackbarText.value = it
             radioConfigRepository.clearErrorMessage()
         }.launchIn(viewModelScope)
+
+        combine(
+            pendingNeighborDiscoveryGpsRecovery,
+            radioConfigRepository.nodeDBbyNum,
+            nodeRegistryMap,
+        ) { pending, _, _ -> pending }
+            .onEach { pending ->
+                if (pending != null && neighborDiscoveryMapAvailability(pending) != null) {
+                    radioConfigRepository.setNeighborDiscoveryResponse(pending)
+                    pendingNeighborDiscoveryGpsRecovery.value = null
+                }
+            }
+            .launchIn(viewModelScope)
 
         radioConfigRepository.localConfigFlow.onEach { config ->
             _localConfig.value = config
@@ -650,6 +677,27 @@ class UIViewModel @Inject constructor(
         } catch (ex: RemoteException) {
             errormsg("Request traceroute error: ${ex.message}")
         }
+    }
+
+    fun requestNeighborDiscovery(destNum: Int) {
+        info("Requesting neighbor discovery for '$destNum'")
+        pendingNeighborDiscoveryGpsRecovery.value = null
+        try {
+            val packetId = meshService?.packetId ?: return
+            meshService?.requestNeighborInfo(packetId, destNum)
+        } catch (ex: RemoteException) {
+            errormsg("Request neighbor discovery error: ${ex.message}")
+        }
+    }
+
+    fun requestNeighborDiscoveryPositions(discovery: NeighborDiscoveryResult) {
+        pendingNeighborDiscoveryGpsRecovery.value = discovery
+
+        val nodeNums = (listOf(discovery.origin.nodeNum) + discovery.discovered.map { it.node.nodeNum })
+            .distinct()
+
+        nodeNums.forEach { requestPosition(it) }
+        showSnackbar(R.string.neighbor_discovery_requesting_gps)
     }
 
     fun removeNode(nodeNum: Int) = viewModelScope.launch(Dispatchers.IO) {
@@ -1263,6 +1311,13 @@ class UIViewModel @Inject constructor(
 
     fun clearTracerouteResponse() {
         radioConfigRepository.clearTracerouteResponse()
+    }
+
+    val neighborDiscoveryResponse: LiveData<NeighborDiscoveryResult?>
+        get() = radioConfigRepository.neighborDiscoveryResponse.asLiveData()
+
+    fun clearNeighborDiscoveryResponse() {
+        radioConfigRepository.clearNeighborDiscoveryResponse()
     }
 
     private val _currentTab = MutableLiveData(0)

--- a/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/repository/datastore/RadioConfigRepository.kt
@@ -22,6 +22,7 @@ import com.geeksville.mesh.database.NodeRepository
 import com.geeksville.mesh.database.entity.MetadataEntity
 import com.geeksville.mesh.database.entity.MyNodeEntity
 import com.geeksville.mesh.database.entity.NodeEntity
+import com.geeksville.mesh.model.NeighborDiscoveryResult
 import com.geeksville.mesh.model.Node
 import com.geeksville.mesh.model.RelayEvent
 import com.geeksville.mesh.model.getChannelUrl
@@ -222,6 +223,17 @@ class RadioConfigRepository @Inject constructor(
 
     fun clearTracerouteResponse() {
         setTracerouteResponse(null)
+    }
+
+    val neighborDiscoveryResponse: StateFlow<NeighborDiscoveryResult?>
+        get() = serviceRepository.neighborDiscoveryResponse
+
+    fun setNeighborDiscoveryResponse(value: NeighborDiscoveryResult?) {
+        serviceRepository.setNeighborDiscoveryResponse(value)
+    }
+
+    fun clearNeighborDiscoveryResponse() {
+        setNeighborDiscoveryResponse(null)
     }
 
     private val _relayEvents = MutableSharedFlow<RelayEvent>(

--- a/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/MeshService.kt
@@ -60,6 +60,8 @@ import com.geeksville.mesh.database.entity.NodeEntity
 import com.geeksville.mesh.database.entity.Packet
 import com.geeksville.mesh.database.entity.ReactionEntity
 import com.geeksville.mesh.model.DeviceVersion
+import com.geeksville.mesh.model.NeighborDiscoveryNode
+import com.geeksville.mesh.model.getNeighborDiscoveryResult
 import com.geeksville.mesh.model.Node
 import com.geeksville.mesh.model.RelayEvent
 import com.geeksville.mesh.model.UIViewModel.Companion.getPreferences
@@ -636,6 +638,49 @@ class MeshService : Service(), Logging {
     private fun getUserShortName(num: Int): String =
         with(radioConfigRepository.getUser(num)) { "$shortName" }
 
+    private fun persistNeighborDiscoveryNode(node: NeighborDiscoveryNode) {
+        updateNodeInfo(node.nodeNum, withBroadcast = false) {
+            val updatedUser = it.user.toBuilder().apply {
+                id = node.userId
+                longName = node.longName
+                shortName = node.shortName
+                hwModel = MeshProtos.HardwareModel.UNSET
+            }.build()
+
+            it.user = updatedUser
+            it.longName = updatedUser.longName
+            it.shortName = updatedUser.shortName
+        }
+
+        serviceScope.handledLaunch {
+            val now = System.currentTimeMillis()
+            val updated = nodeRegistryRepository.updateNodeInfo(
+                nodeId = node.userId,
+                nodeNum = node.nodeNum,
+                longName = node.longName,
+                shortName = node.shortName,
+                lastSeen = now,
+            )
+
+            if (updated == 0) {
+                nodeRegistryRepository.insertNodeInfo(
+                    nodeId = node.userId,
+                    nodeNum = node.nodeNum,
+                    longName = node.longName,
+                    shortName = node.shortName,
+                    defaultName = "Meshtastic ${node.userId.takeLast(n = 4)}",
+                    lastSeen = now,
+                )
+            }
+        }
+    }
+
+    private fun persistNeighborDiscoveryNodes(packet: MeshPacket) {
+        val discovery = packet.getNeighborDiscoveryResult { nodeNum -> nodeDBbyNodeNum[nodeNum]?.user } ?: return
+        persistNeighborDiscoveryNode(discovery.origin)
+        discovery.discovered.forEach { persistNeighborDiscoveryNode(it.node) }
+    }
+
     private val numNodes get() = nodeDBbyNodeNum.size
 
     /**
@@ -1076,6 +1121,16 @@ class MeshService : Service(), Logging {
                             }
 
                             radioConfigRepository.setTracerouteResponse(traceRouteResponse)
+                        }
+                    }
+
+                    Portnums.PortNum.NEIGHBORINFO_APP_VALUE -> {
+                        persistNeighborDiscoveryNodes(packet)
+
+                        if (!huntingPrefs.getBoolean(UserPrefs.Hunting.BACKGROUND_HUNT, false)) {
+                            radioConfigRepository.setNeighborDiscoveryResponse(
+                                packet.getNeighborDiscoveryResult { nodeNum -> nodeDBbyNodeNum[nodeNum]?.user }
+                            )
                         }
                     }
 
@@ -2699,6 +2754,19 @@ class MeshService : Service(), Logging {
             }
 
             sendToRadio(tracePacket)
+        }
+
+        override fun requestNeighborInfo(requestId: Int, destNum: Int) = toRemoteExceptions {
+            val neighborPacket = newMeshPacketTo(destNum).buildMeshPacket(
+                wantAck = true,
+                id = requestId,
+                channel = nodeDBbyNodeNum[destNum]?.channel ?: 0,
+            ) {
+                portnumValue = Portnums.PortNum.NEIGHBORINFO_APP_VALUE
+                wantResponse = true
+            }
+
+            sendToRadio(neighborPacket)
         }
 
         override fun requestShutdown(requestId: Int, destNum: Int) = toRemoteExceptions {

--- a/app/src/main/java/com/geeksville/mesh/service/ServiceRepository.kt
+++ b/app/src/main/java/com/geeksville/mesh/service/ServiceRepository.kt
@@ -19,6 +19,7 @@ package com.geeksville.mesh.service
 
 import com.geeksville.mesh.IMeshService
 import com.geeksville.mesh.android.Logging
+import com.geeksville.mesh.model.NeighborDiscoveryResult
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -86,6 +87,17 @@ class ServiceRepository @Inject constructor() : Logging {
 
     fun clearTracerouteResponse() {
         setTracerouteResponse(null)
+    }
+
+    private val _neighborDiscoveryResponse = MutableStateFlow<NeighborDiscoveryResult?>(null)
+    val neighborDiscoveryResponse: StateFlow<NeighborDiscoveryResult?> get() = _neighborDiscoveryResponse
+
+    fun setNeighborDiscoveryResponse(value: NeighborDiscoveryResult?) {
+        _neighborDiscoveryResponse.value = value
+    }
+
+    fun clearNeighborDiscoveryResponse() {
+        setNeighborDiscoveryResponse(null)
     }
 
     private val _serviceAction = Channel<ServiceAction>()

--- a/app/src/main/java/com/geeksville/mesh/ui/AdvancedSettings.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/AdvancedSettings.kt
@@ -32,6 +32,8 @@ const val AUTO_DELETE_PRESERVE_FAVOURITES = "auto_delete_preserve_favourites"
 const val REMOVE_CUSTOM_ICON_CHAT = "remove_custom_icon_chat"
 const val USE_COMPRESSION_MESSAGES = "use_compression_messages"
 const val COMPRESSED_CHATS_PREFS = "compressed_chats_prefs"
+const val SHOW_AIRUTIL_CHUTIL = "show_airutil_chutil"
+const val SHOW_AIRUTIL_CHUTIL_ALL_NODES = "show_airutil_chutil_all_nodes"
 
 object AutoDeleteConfig {
 
@@ -85,6 +87,12 @@ class AdvancedSettings : AppCompatActivity() {
         val useCompressionSwitch =
             findViewById<SwitchCompat>(R.id.useCompressionSwitch)
 
+        val showAirUtilChUtilSwitch =
+            findViewById<SwitchCompat>(R.id.showAirUtilChUtilSwitch)
+
+        val showAirUtilChUtilAllNodesSwitch =
+            findViewById<SwitchCompat>(R.id.showAirUtilChUtilAllNodesSwitch)
+
         val autoDeleteTimeSpinner = findViewById<Spinner>(R.id.autoDeleteTiming)
 
         val autoDeleteNodesHoursAdapter = ArrayAdapter(
@@ -102,6 +110,8 @@ class AdvancedSettings : AppCompatActivity() {
         val autoDeletePreserveFavPref = advancedPrefs.getBoolean(AUTO_DELETE_PRESERVE_FAVOURITES, false)
         val removeCustomIconChatPrefs = advancedPrefs.getBoolean(REMOVE_CUSTOM_ICON_CHAT, false)
         val useMessageCompressionPrefs = advancedPrefs.getBoolean(USE_COMPRESSION_MESSAGES, false)
+        val showAirUtilChUtilPrefs = advancedPrefs.getBoolean(SHOW_AIRUTIL_CHUTIL, false)
+        val showAirUtilChUtilAllNodesPrefs = advancedPrefs.getBoolean(SHOW_AIRUTIL_CHUTIL_ALL_NODES, false)
 
         val autoDeleteTimeHours = advancedPrefs.getInt(
             AUTO_DELETE_TIME_HOURS,
@@ -121,6 +131,16 @@ class AdvancedSettings : AppCompatActivity() {
         autoDeletePreserveFav.isChecked = autoDeletePreserveFavPref
         removeCustomIconChatSwitch.isChecked = removeCustomIconChatPrefs
         useCompressionSwitch.isChecked = useMessageCompressionPrefs
+        showAirUtilChUtilSwitch.isChecked = showAirUtilChUtilPrefs
+        showAirUtilChUtilAllNodesSwitch.isChecked = showAirUtilChUtilAllNodesPrefs
+
+        fun updateAirUtilChUtilSectionState() {
+            val enabled = showAirUtilChUtilSwitch.isChecked
+            showAirUtilChUtilAllNodesSwitch.isEnabled = enabled
+            showAirUtilChUtilAllNodesSwitch.alpha = if (enabled) 1f else 0.5f
+        }
+
+        updateAirUtilChUtilSectionState()
 
         val autoDeleteSpinnerIndex = hoursValues
             .indexOf(autoDeleteTimeHours)
@@ -136,6 +156,10 @@ class AdvancedSettings : AppCompatActivity() {
         setSwitchListener(autoDeletePreserveFav, AUTO_DELETE_PRESERVE_FAVOURITES)
         setSwitchListener(removeCustomIconChatSwitch, REMOVE_CUSTOM_ICON_CHAT)
         setSwitchListener(useCompressionSwitch, USE_COMPRESSION_MESSAGES)
+        setSwitchListener(showAirUtilChUtilSwitch, SHOW_AIRUTIL_CHUTIL) {
+            updateAirUtilChUtilSectionState()
+        }
+        setSwitchListener(showAirUtilChUtilAllNodesSwitch, SHOW_AIRUTIL_CHUTIL_ALL_NODES)
 
         autoDeleteTimeSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(
@@ -184,7 +208,11 @@ class AdvancedSettings : AppCompatActivity() {
 
     }
 
-    private fun setSwitchListener(switchCompat: SwitchCompat, prefsFlag: String){
+    private fun setSwitchListener(
+        switchCompat: SwitchCompat,
+        prefsFlag: String,
+        onChanged: ((Boolean) -> Unit)? = null,
+    ){
         switchCompat.setOnCheckedChangeListener { _, isChecked ->
 
             if(isChecked){
@@ -192,6 +220,8 @@ class AdvancedSettings : AppCompatActivity() {
             } else {
                 advancedPrefs.edit { putBoolean(prefsFlag, false) }
             }
+
+            onChanged?.invoke(isChecked)
         }
     }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/NavGraph.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/NavGraph.kt
@@ -81,6 +81,7 @@ import com.geeksville.mesh.model.RadioConfigViewModel
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.ui.components.DeviceMetricsScreen
 import com.geeksville.mesh.ui.components.EnvironmentMetricsScreen
+import com.geeksville.mesh.ui.components.NeighborDiscoveryLogScreen
 import com.geeksville.mesh.ui.components.NodeMapScreen
 import com.geeksville.mesh.ui.components.PositionLogScreen
 import com.geeksville.mesh.ui.components.SignalMetricsScreen
@@ -291,6 +292,9 @@ sealed interface Route {
 
     @Serializable
     data object TracerouteLog : Route
+
+    @Serializable
+    data object NeighborDiscoveryLog : Route
 }
 
 // Config (type = AdminProtos.AdminMessage.ConfigType)
@@ -476,6 +480,16 @@ fun NavGraph(
         composable<Route.TracerouteLog> {
             val parentEntry = remember { navController.getBackStackEntry<Route.NodeDetail>() }
             TracerouteLogScreen(
+                uiModel,
+                hiltViewModel<MetricsViewModel>(parentEntry),
+                onClose = {
+                    parentFragmentManager.popBackStack()
+                }
+            )
+        }
+        composable<Route.NeighborDiscoveryLog> {
+            val parentEntry = remember { navController.getBackStackEntry<Route.NodeDetail>() }
+            NeighborDiscoveryLogScreen(
                 uiModel,
                 hiltViewModel<MetricsViewModel>(parentEntry),
                 onClose = {

--- a/app/src/main/java/com/geeksville/mesh/ui/NodeDetail.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/NodeDetail.kt
@@ -65,6 +65,7 @@ import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Map
 import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.Numbers
+import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Power
 import androidx.compose.material.icons.filled.Route
@@ -485,6 +486,14 @@ fun LogNavigationList(state: MetricsState, onNavigate: (Any) -> Unit) {
         enabled = state.hasTracerouteLogs()
     ) {
         onNavigate(Route.TracerouteLog)
+    }
+
+    NavCard(
+        title = stringResource(R.string.neighbor_discovery_log),
+        icon = Icons.Default.People,
+        enabled = state.hasNeighborDiscoveryLogs()
+    ) {
+        onNavigate(Route.NeighborDiscoveryLog)
     }
 }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/NodeItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/NodeItem.kt
@@ -119,6 +119,7 @@ import kotlinx.coroutines.delay
 import org.meshtastic.proto.ConfigProtos.Config.DeviceConfig
 import org.meshtastic.proto.ConfigProtos.Config.DisplayConfig
 import org.meshtastic.proto.MeshProtos
+import org.meshtastic.proto.TelemetryProtos
 
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 @OptIn(ExperimentalMaterialApi::class, ExperimentalMaterial3Api::class)
@@ -142,6 +143,18 @@ fun NodeItem(
     val removeCustomIconChatPrefs by rememberBooleanPreference(
         context.advancedPrefs,
         REMOVE_CUSTOM_ICON_CHAT,
+        false
+    )
+
+    val showAirUtilChUtilPrefs by rememberBooleanPreference(
+        context.advancedPrefs,
+        SHOW_AIRUTIL_CHUTIL,
+        false
+    )
+
+    val showAirUtilChUtilAllNodesPrefs by rememberBooleanPreference(
+        context.advancedPrefs,
+        SHOW_AIRUTIL_CHUTIL_ALL_NODES,
         false
     )
 
@@ -181,6 +194,17 @@ fun NodeItem(
     }
 
     val infrastructure = AppUtil.isInfrastructure(roleName)
+    val airUtilChUtilInfrastructureRole = roleName in setOf(
+        DeviceConfig.Role.CLIENT_BASE.name,
+        DeviceConfig.Role.ROUTER.name,
+        DeviceConfig.Role.ROUTER_LATE.name,
+    )
+    val hasDeviceMetricsTelemetry =
+        thatNode.deviceMetrics != TelemetryProtos.DeviceMetrics.getDefaultInstance()
+    val shouldShowAirUtilChUtil =
+        showAirUtilChUtilPrefs &&
+            hasDeviceMetricsTelemetry &&
+            (showAirUtilChUtilAllNodesPrefs || airUtilChUtilInfrastructureRole)
 
     val (detailsShown, showDetails) = remember { mutableStateOf(expanded) }
 
@@ -427,6 +451,22 @@ fun NodeItem(
                             fontSize = MaterialTheme.typography.button.fontSize,
                             style = style,
                         )
+                    }
+
+                    if (shouldShowAirUtilChUtil) {
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Text(
+                                text = stringResource(R.string.channel_air_util).format(
+                                    thatNode.deviceMetrics.channelUtilization,
+                                    thatNode.deviceMetrics.airUtilTx,
+                                ),
+                                fontSize = MaterialTheme.typography.button.fontSize,
+                                style = style,
+                            )
+                        }
                     }
                 }
 

--- a/app/src/main/java/com/geeksville/mesh/ui/NodeItem.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/NodeItem.kt
@@ -89,12 +89,15 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -116,6 +119,7 @@ import com.geeksville.mesh.util.ComposableUtil.rememberBooleanPreference
 import com.geeksville.mesh.util.IdentIkonGen
 import com.geeksville.mesh.util.toDistanceString
 import kotlinx.coroutines.delay
+import java.util.Locale
 import org.meshtastic.proto.ConfigProtos.Config.DeviceConfig
 import org.meshtastic.proto.ConfigProtos.Config.DisplayConfig
 import org.meshtastic.proto.MeshProtos
@@ -458,11 +462,28 @@ fun NodeItem(
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                         ) {
+                            val channelUtilization = thatNode.deviceMetrics.channelUtilization
+                            val airUtilTx = thatNode.deviceMetrics.airUtilTx
                             Text(
-                                text = stringResource(R.string.channel_air_util).format(
-                                    thatNode.deviceMetrics.channelUtilization,
-                                    thatNode.deviceMetrics.airUtilTx,
-                                ),
+                                text = buildAnnotatedString {
+                                    append("ChUtil ")
+                                    withStyle(
+                                        SpanStyle(
+                                            color = AppUtil.channelUtilizationColor(channelUtilization)
+                                        )
+                                    ) {
+                                        append(formatMetricPercent(channelUtilization))
+                                    }
+                                    append(" AirUtilTX ")
+                                    withStyle(
+                                        SpanStyle(
+                                            color = AppUtil.airUtilTxColor(airUtilTx)
+                                        )
+                                    ) {
+                                        append(formatMetricPercent(airUtilTx))
+                                    }
+                                },
+                                color = MaterialTheme.colors.onSurface,
                                 fontSize = MaterialTheme.typography.button.fontSize,
                                 style = style,
                             )
@@ -477,6 +498,9 @@ fun NodeItem(
         }
     }
 }
+
+private fun formatMetricPercent(value: Float): String =
+    String.format(Locale.getDefault(), "%.1f%%", value)
 
 @Composable
 @Preview(showBackground = false)

--- a/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
@@ -222,6 +222,7 @@ fun NodesScreen(
                         is NodeMenuAction.RequestUserInfo -> model.requestUserInfo(node.num)
                         is NodeMenuAction.RequestPosition -> model.requestPosition(node.num)
                         is NodeMenuAction.TraceRoute -> model.requestTraceroute(node.num)
+                        is NodeMenuAction.NeighborDiscovery -> model.requestNeighborDiscovery(node.num)
                         is NodeMenuAction.MoreDetails -> navigateToNodeDetails(node.num)
                         is NodeMenuAction.FavoriteNode -> model.handleFavorite(node)
                         is NodeMenuAction.RequestDeviceMetadata -> model.requestDeviceMetadata(node)

--- a/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
@@ -70,6 +70,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -99,6 +100,14 @@ import kotlinx.coroutines.delay
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import org.meshtastic.proto.TelemetryProtos.DeviceMetrics
+
+private const val CH_UTIL_GOOD_THRESHOLD = 25f
+private const val CH_UTIL_FAIR_THRESHOLD = 50f
+private const val AIR_UTIL_GOOD_THRESHOLD = 3f
+private const val AIR_UTIL_FAIR_THRESHOLD = 5f
+private const val AIR_UTIL_BAD_THRESHOLD = 7f
+private const val AIR_UTIL_REALLY_BAD_THRESHOLD = 10f
 
 @AndroidEntryPoint
 class UsersFragment : ScreenFragment("Users"), Logging {
@@ -244,12 +253,17 @@ fun NodesScreen(
 fun RelayInfoBox(relayNode: RelayEvent, model: UIViewModel) {
 
     val context = LocalContext.current
+    val nodes by model.unfilteredNodeList.collectAsStateWithLifecycle()
     val nodeName = relayNode.nodeLongName ?: "undefined"
     val shortName = relayNode.nodeShortName ?: "undefined"
     val nodeNum = relayNode.relayNodeNum
     val timeLabel = formatRelayTime(relayNode.timestamp)
     val rxSnr = relayNode.rxSnr
     val rxRssi = relayNode.rxRssi
+    val relayMetrics = nodes
+        .firstOrNull { it.num == nodeNum }
+        ?.deviceMetrics
+        ?.takeIf { it != DeviceMetrics.getDefaultInstance() }
     val (foregroundColor, backgroundColor) = AppUtil.getNodeColorLabel(nodeNum)
 
     val snrColor = when {
@@ -264,12 +278,22 @@ fun RelayInfoBox(relayNode: RelayEvent, model: UIViewModel) {
         else -> Quality.BAD.color
     }
 
+    val chUtilColor = relayMetrics
+        ?.channelUtilization
+        ?.let(::relayChUtilColor)
+        ?: Quality.FAIR.color
+
+    val airUtilColor = relayMetrics
+        ?.airUtilTx
+        ?.let(::relayAirUtilColor)
+        ?: Quality.FAIR.color
+
     val confidenceColor = AppUtil.relayNodePacketLabelColor(relayNode.confidence)
     var confidence = relayNode.confidence.toString() + "%"
 
-    if(relayNode.isTraceroute){
+    if (relayNode.isTraceroute) {
         confidence += " (TRACE)"
-    } else if(relayNode.isDirect){
+    } else if (relayNode.isDirect) {
         confidence += " (DIRECT)"
     }
 
@@ -282,10 +306,7 @@ fun RelayInfoBox(relayNode: RelayEvent, model: UIViewModel) {
     }
 
     val borderColor by animateColorAsState(
-        targetValue = if (highlight)
-            Color.Green
-        else
-            Color.Transparent,
+        targetValue = if (highlight) Color.Green else Color.Transparent,
         animationSpec = tween(durationMillis = 900)
     )
 
@@ -308,26 +329,37 @@ fun RelayInfoBox(relayNode: RelayEvent, model: UIViewModel) {
                     model.filterForNode(null, nodeName)
                 }
             )
-    )  {
-
+    ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(7.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(
-                    4.dp,
-                    Alignment.CenterHorizontally
-                ),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
+                Box(
+                    modifier = Modifier
+                        .background(
+                            color = Color(backgroundColor),
+                            shape = RoundedCornerShape(50)
+                        )
+                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                ) {
+                    Text(
+                        color = Color(foregroundColor),
+                        text = shortName,
+                        fontSize = 14.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
 
                 Text(
-                    text = "Closest Relay Confidence :",
+                    text = "GRC",
                     fontSize = 14.sp,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
@@ -339,81 +371,19 @@ fun RelayInfoBox(relayNode: RelayEvent, model: UIViewModel) {
                             confidenceColor,
                             RoundedCornerShape(6.dp)
                         )
-                        .padding(horizontal = 5.dp, vertical = 0.dp)
+                        .padding(horizontal = 8.dp, vertical = 4.dp)
                 ) {
                     Text(
                         text = confidence,
                         color = Color.Black,
-                        style = MaterialTheme.typography.labelSmall,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
-            }
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(
-                    9.dp,
-                    Alignment.CenterHorizontally
-                ),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-
-                Box(
-                    modifier = Modifier
-                        .background(
-                            color = Color(backgroundColor),
-                            shape = RoundedCornerShape(50)
-                        )
-                        .padding(horizontal = 8.dp, vertical = 4.dp)
-                )  {
-                    Text(
-                        color = Color(foregroundColor),
-                        text = shortName,
-                        fontSize = 14.sp,
+                        style = MaterialTheme.typography.labelMedium,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
                 }
 
-                if (rxSnr != Float.MAX_VALUE) {
-                    Box(
-                        modifier = Modifier
-                            .background(
-                                snrColor,
-                                RoundedCornerShape(6.dp)
-                            )
-                            .padding(horizontal = 8.dp, vertical = 4.dp)
-                    ) {
-                        Text(
-                            text = "SNR ${rxSnr}dB",
-                            color = Color.Black,
-                            style = MaterialTheme.typography.labelMedium,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-                }
+                Spacer(modifier = Modifier.weight(1f))
 
-                if (rxRssi != Int.MAX_VALUE) {
-                    Box(
-                        modifier = Modifier
-                            .background(
-                                rssiColor,
-                                RoundedCornerShape(6.dp)
-                            )
-                            .padding(horizontal = 8.dp, vertical = 4.dp)
-                    ) {
-                        Text(
-                            text = "RSSI ${rxRssi}dBm",
-                            color = Color.Black,
-                            style = MaterialTheme.typography.labelMedium,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-                }
                 Text(
                     text = timeLabel,
                     fontSize = 14.sp,
@@ -421,8 +391,91 @@ fun RelayInfoBox(relayNode: RelayEvent, model: UIViewModel) {
                     overflow = TextOverflow.Ellipsis
                 )
             }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                RelayMetricBadge(
+                    text = if (rxSnr != Float.MAX_VALUE) "SNR ${rxSnr}dB" else "SNR --",
+                    color = if (rxSnr != Float.MAX_VALUE) snrColor else Quality.FAIR.color,
+                    modifier = Modifier.weight(1f),
+                )
+
+                RelayMetricBadge(
+                    text = if (rxRssi != Int.MAX_VALUE) "RSSI ${rxRssi}dBm" else "RSSI --",
+                    color = if (rxRssi != Int.MAX_VALUE) rssiColor else Quality.FAIR.color,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                RelayMetricBadge(
+                    text = relayMetrics?.let {
+                        "ChUtil ${formatRelayPercent(it.channelUtilization)}"
+                    } ?: "ChUtil --",
+                    color = if (relayMetrics != null) chUtilColor else Quality.FAIR.color,
+                    modifier = Modifier.weight(1f),
+                )
+
+                RelayMetricBadge(
+                    text = relayMetrics?.let {
+                        "AirUtil ${formatRelayPercent(it.airUtilTx)}"
+                    } ?: "AirUtil --",
+                    color = if (relayMetrics != null) airUtilColor else Quality.FAIR.color,
+                    modifier = Modifier.weight(1f),
+                )
+            }
         }
     }
+}
+
+@Composable
+private fun RelayMetricBadge(
+    text: String,
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .background(
+                color,
+                RoundedCornerShape(6.dp)
+            )
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    ) {
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            text = text,
+            color = Color.Black,
+            style = MaterialTheme.typography.labelMedium,
+            textAlign = TextAlign.Center,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+private fun formatRelayPercent(value: Float): String =
+    "${String.format(Locale.getDefault(), "%.1f", value)}%"
+
+private fun relayChUtilColor(value: Float): Color = when {
+    value < CH_UTIL_GOOD_THRESHOLD -> Quality.GOOD.color
+    value < CH_UTIL_FAIR_THRESHOLD -> Quality.FAIR.color
+    else -> Quality.BAD.color
+}
+
+private fun relayAirUtilColor(value: Float): Color = when {
+    value < AIR_UTIL_GOOD_THRESHOLD -> Quality.GOOD.color
+    value < AIR_UTIL_FAIR_THRESHOLD -> Quality.FAIR.color
+    value < AIR_UTIL_BAD_THRESHOLD -> Quality.BAD.color
+    value < AIR_UTIL_REALLY_BAD_THRESHOLD -> Quality.REALLY_BAD.color
+    else -> Quality.REALLY_BAD.color
 }
 
 @Composable

--- a/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/UsersFragment.kt
@@ -102,13 +102,6 @@ import java.util.Date
 import java.util.Locale
 import org.meshtastic.proto.TelemetryProtos.DeviceMetrics
 
-private const val CH_UTIL_GOOD_THRESHOLD = 25f
-private const val CH_UTIL_FAIR_THRESHOLD = 50f
-private const val AIR_UTIL_GOOD_THRESHOLD = 3f
-private const val AIR_UTIL_FAIR_THRESHOLD = 5f
-private const val AIR_UTIL_BAD_THRESHOLD = 7f
-private const val AIR_UTIL_REALLY_BAD_THRESHOLD = 10f
-
 @AndroidEntryPoint
 class UsersFragment : ScreenFragment("Users"), Logging {
 
@@ -280,12 +273,12 @@ fun RelayInfoBox(relayNode: RelayEvent, model: UIViewModel) {
 
     val chUtilColor = relayMetrics
         ?.channelUtilization
-        ?.let(::relayChUtilColor)
+        ?.let(AppUtil::channelUtilizationColor)
         ?: Quality.FAIR.color
 
     val airUtilColor = relayMetrics
         ?.airUtilTx
-        ?.let(::relayAirUtilColor)
+        ?.let(AppUtil::airUtilTxColor)
         ?: Quality.FAIR.color
 
     val confidenceColor = AppUtil.relayNodePacketLabelColor(relayNode.confidence)
@@ -463,20 +456,6 @@ private fun RelayMetricBadge(
 
 private fun formatRelayPercent(value: Float): String =
     "${String.format(Locale.getDefault(), "%.1f", value)}%"
-
-private fun relayChUtilColor(value: Float): Color = when {
-    value < CH_UTIL_GOOD_THRESHOLD -> Quality.GOOD.color
-    value < CH_UTIL_FAIR_THRESHOLD -> Quality.FAIR.color
-    else -> Quality.BAD.color
-}
-
-private fun relayAirUtilColor(value: Float): Color = when {
-    value < AIR_UTIL_GOOD_THRESHOLD -> Quality.GOOD.color
-    value < AIR_UTIL_FAIR_THRESHOLD -> Quality.FAIR.color
-    value < AIR_UTIL_BAD_THRESHOLD -> Quality.BAD.color
-    value < AIR_UTIL_REALLY_BAD_THRESHOLD -> Quality.REALLY_BAD.color
-    else -> Quality.REALLY_BAD.color
-}
 
 @Composable
 fun DbImportInfoBox(

--- a/app/src/main/java/com/geeksville/mesh/ui/components/NeighborDiscoveryLog.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/NeighborDiscoveryLog.kt
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2026 Meshtastic LLC
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.geeksville.mesh.ui.components
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Card
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.People
+import androidx.compose.material.icons.filled.PersonOff
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.emp3r0r7.darkmesh.R
+import com.geeksville.mesh.model.MetricsViewModel
+import com.geeksville.mesh.model.NeighborDiscoveryResult
+import com.geeksville.mesh.model.UIViewModel
+import com.geeksville.mesh.model.formatNeighborDiscoverySnr
+import com.geeksville.mesh.model.getNeighborDiscoveryResult
+import com.geeksville.mesh.model.neighborDiscoverySnrColor
+import java.text.DateFormat
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun NeighborDiscoveryLogScreen(
+    uiViewModel: UIViewModel = hiltViewModel(),
+    viewModel: MetricsViewModel = hiltViewModel(),
+    modifier: Modifier = Modifier,
+    onClose: () -> Unit,
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+    val dateFormat = remember {
+        DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM)
+    }
+    var showDialog by remember { mutableStateOf<NeighborDiscoveryResult?>(null) }
+    var showMapUnavailableDialog by remember { mutableStateOf<NeighborDiscoveryResult?>(null) }
+
+    showMapUnavailableDialog?.let { discovery ->
+        AlertDialog(
+            onDismissRequest = {
+                showMapUnavailableDialog = null
+            },
+            title = {},
+            text = {
+                Text(text = stringResource(R.string.neighbor_discovery_request_gps_prompt))
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showMapUnavailableDialog = null
+                        uiViewModel.requestNeighborDiscoveryPositions(discovery)
+                    }
+                ) {
+                    Text(
+                        text = stringResource(android.R.string.yes),
+                        color = colorResource(id = R.color.colorAnnotation),
+                    )
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showMapUnavailableDialog = null }) {
+                    Text(
+                        text = stringResource(android.R.string.no),
+                        color = colorResource(id = R.color.colorAnnotation),
+                    )
+                }
+            },
+        )
+    }
+
+    showDialog?.let { discovery ->
+        NeighborDiscoveryDialog(
+            discovery = discovery,
+            onDismiss = {
+                showDialog = null
+                uiViewModel.clearNeighborDiscoveryResponse()
+            },
+            onViewOnMap = {
+                showDialog = null
+                uiViewModel.neighborDiscoveryMapAvailability(discovery)
+                    ?.let {
+                        onClose()
+                        uiViewModel.showNeighborDiscoveryMap(it)
+                    }
+                    ?: run {
+                        showMapUnavailableDialog = discovery
+                    }
+            }
+        )
+    }
+
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(horizontal = 16.dp),
+    ) {
+        items(state.neighborDiscoveryRequests, key = { it.uuid }) { log ->
+            val result = remember(state.neighborDiscoveryResults) {
+                state.neighborDiscoveryResults.find { it.decoded.requestId == log.fromRadio.packet.id }
+            }
+            val discovery = remember(result) { result?.getNeighborDiscoveryResult(viewModel::getUser) }
+            val time = dateFormat.format(log.received_date)
+            val text = discoverySummary(discovery)
+            val icon = if (discovery == null) Icons.Default.PersonOff else Icons.Default.People
+            var expanded by remember { mutableStateOf(false) }
+
+            Box {
+                NeighborDiscoveryItem(
+                    icon = icon,
+                    text = "$time - $text",
+                    modifier = Modifier.combinedClickable(
+                        onLongClick = { expanded = true },
+                    ) {
+                        if (discovery != null) {
+                            showDialog = discovery
+                        }
+                    }
+                )
+                DropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false },
+                ) {
+                    DeleteNeighborDiscoveryItem {
+                        viewModel.deleteLog(log.uuid)
+                        expanded = false
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun NeighborDiscoveryDialog(
+    discovery: NeighborDiscoveryResult,
+    onDismiss: () -> Unit,
+    onViewOnMap: (() -> Unit)? = null,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {},
+        text = {
+            NeighborDiscoveryContent(discovery = discovery)
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(
+                    text = stringResource(R.string.okay),
+                    color = colorResource(id = R.color.colorAnnotation),
+                )
+            }
+        },
+        dismissButton = {
+            if (onViewOnMap != null) {
+                TextButton(onClick = onViewOnMap) {
+                    Text(
+                        text = stringResource(R.string.view_on_map),
+                        color = colorResource(id = R.color.colorAnnotation),
+                    )
+                }
+            }
+        }
+    )
+}
+
+@Composable
+fun NeighborDiscoveryContent(
+    discovery: NeighborDiscoveryResult,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(R.string.neighbor_discovery),
+            style = MaterialTheme.typography.h6,
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            text = discovery.origin.longName,
+            style = MaterialTheme.typography.subtitle1,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.width(1.dp).padding(top = 8.dp))
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 360.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            if (discovery.discovered.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.neighbor_discovery_no_neighbors),
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.body1,
+                )
+            } else {
+                discovery.discovered.forEach { link ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = link.node.longName,
+                            modifier = Modifier.weight(1f),
+                            style = MaterialTheme.typography.body1,
+                        )
+                        Text(
+                            text = formatNeighborDiscoverySnr(link.snr),
+                            color = Color(neighborDiscoverySnrColor(link.snr)),
+                            fontWeight = FontWeight.Bold,
+                            style = MaterialTheme.typography.body1,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DeleteNeighborDiscoveryItem(onClick: () -> Unit) {
+    DropdownMenuItem(onClick = onClick) {
+        Icon(
+            imageVector = Icons.Default.Delete,
+            contentDescription = stringResource(id = R.string.delete),
+            tint = MaterialTheme.colors.error,
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = stringResource(id = R.string.delete),
+            color = MaterialTheme.colors.error,
+        )
+    }
+}
+
+@Composable
+private fun NeighborDiscoveryItem(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(min = 56.dp)
+            .padding(vertical = 2.dp),
+        elevation = 4.dp,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = stringResource(id = R.string.neighbor_discovery),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = text,
+                style = MaterialTheme.typography.body1,
+            )
+        }
+    }
+}
+
+@Composable
+private fun discoverySummary(discovery: NeighborDiscoveryResult?): String = when {
+    discovery == null -> stringResource(R.string.routing_error_no_response)
+    discovery.discovered.isEmpty() -> stringResource(R.string.neighbor_discovery_no_neighbors)
+    else -> pluralStringResource(
+        R.plurals.neighbor_discovery_nodes,
+        discovery.discovered.size,
+        discovery.discovered.size,
+    )
+}

--- a/app/src/main/java/com/geeksville/mesh/ui/components/NodeMenu.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/components/NodeMenu.kt
@@ -178,6 +178,13 @@ fun NodeMenu(
                 content = { Text(stringResource(R.string.traceroute)) }
             )
             DropdownMenuItem(
+                onClick = {
+                    onDismissRequest()
+                    onAction(NodeMenuAction.NeighborDiscovery(node))
+                },
+                content = { Text(stringResource(R.string.neighbor_discovery)) }
+            )
+            DropdownMenuItem(
                 enabled = isKnownNode.value,
                 onClick = {
                     onDismissRequest()
@@ -247,6 +254,7 @@ sealed class NodeMenuAction {
     data class RequestDeviceMetadata(val node: Node) : NodeMenuAction()
     data class RequestPosition(val node: Node) : NodeMenuAction()
     data class TraceRoute(val node: Node) : NodeMenuAction()
+    data class NeighborDiscovery(val node: Node) : NodeMenuAction()
     data class FavoriteNode(val node: Node) : NodeMenuAction()
     data class MoreDetails(val node: Node) : NodeMenuAction()
 }

--- a/app/src/main/java/com/geeksville/mesh/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/map/MapFragment.kt
@@ -39,6 +39,7 @@ import androidx.compose.material.Scaffold
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.LocationDisabled
+import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.Route
 import androidx.compose.material.icons.outlined.Layers
 import androidx.compose.material.icons.outlined.MyLocation
@@ -73,14 +74,18 @@ import com.geeksville.mesh.android.hasGps
 import com.geeksville.mesh.android.hasLocationPermission
 import com.geeksville.mesh.database.entity.Packet
 import com.geeksville.mesh.model.MapMode
+import com.geeksville.mesh.model.NeighborDiscoveryMap
 import com.geeksville.mesh.model.Node
 import com.geeksville.mesh.model.TraceRouteMap
 import com.geeksville.mesh.model.UIViewModel
 import com.geeksville.mesh.model.colorizeTracerouteResponse
+import com.geeksville.mesh.model.neighborDiscoverySnrColor
 import com.geeksville.mesh.model.map.CustomTileSource
 import com.geeksville.mesh.model.map.MarkerWithLabel
 import com.geeksville.mesh.model.map.clustering.RadiusMarkerClusterer
 import com.geeksville.mesh.ui.ScreenFragment
+import com.geeksville.mesh.ui.components.NeighborDiscoveryContent
+import com.geeksville.mesh.ui.components.NeighborDiscoveryDialog
 import com.geeksville.mesh.ui.theme.AppTheme
 import com.geeksville.mesh.util.AppUtil
 import com.geeksville.mesh.util.SqlTileWriterExt
@@ -293,6 +298,24 @@ fun MapView.drawTraceroute(trace: TraceRouteMap) {
     invalidate()
 }
 
+fun MapView.drawNeighborDiscovery(discovery: NeighborDiscoveryMap) {
+    overlays.removeAll { it is Polyline || it is Marker }
+
+    discovery.links.mapNotNull { link ->
+        buildMapSegment(
+            fromNode = link.origin,
+            toNode = link.discovered,
+            color = neighborDiscoverySnrColor(link.snr),
+            offsetMeters = 0.0,
+            side = 1,
+        )
+    }.forEach {
+        overlays.add(it.toPolyline())
+    }
+
+    invalidate()
+}
+
 
 fun totalDistanceKm(nodes: List<Node>): Double {
     fun haversine(a: GeoPoint, b: GeoPoint): Double {
@@ -328,51 +351,52 @@ fun buildSegments(
     side: Int
 ): List<MapSegment> =
     nodes.zipWithNext().mapNotNull { (a, b) ->
+        buildMapSegment(a, b, color, offsetMeters, side)
+    }
 
-        //fixme, refactor this part
-        var latA = Double.NaN
-        var lonA = Double.NaN
+private fun Node.toGeoPointOrNull(): GeoPoint? = when {
+    validPosition != null -> GeoPoint(latitude, longitude)
+    validLiteNode && liteLatitude != null && liteLongitude != null -> GeoPoint(liteLatitude, liteLongitude)
+    else -> null
+}
 
-        var latB = Double.NaN
-        var lonB = Double.NaN
+private fun buildMapSegment(
+    fromNode: Node,
+    toNode: Node,
+    color: Int,
+    offsetMeters: Double,
+    side: Int,
+): MapSegment? {
+    val rawFrom = fromNode.toGeoPointOrNull() ?: return null
+    val rawTo = toNode.toGeoPointOrNull() ?: return null
 
-        if (a.validPosition != null) {
-            latA = a.latitude
-            lonA = a.longitude
-        } else if (a.validLiteNode && a.liteLatitude != null && a.liteLongitude != null) {
-            latA = a.liteLatitude
-            lonA = a.liteLongitude
-        }
+    if (!validCoordinates(rawFrom.latitude, rawFrom.longitude) ||
+        !validCoordinates(rawTo.latitude, rawTo.longitude)
+    ) {
+        return null
+    }
 
-        if (b.validPosition != null) {
-            latB = b.latitude
-            lonB = b.longitude
-        } else if (b.validLiteNode && b.liteLatitude != null && b.liteLongitude != null) {
-            latB = b.liteLatitude
-            lonB = b.liteLongitude
-        }
-
-        if(!validCoordinates(latA, lonA) || !validCoordinates(latB, lonB)){
-            return@mapNotNull null
-        }
-
-        val rawFrom = GeoPoint(latA, lonA)
-        val rawTo = GeoPoint(latB, lonB)
-
-        // normalizza: sempre da sud a nord (o qualsiasi criterio stabile)
-        val (from, to) =
-            if (rawFrom.latitude < rawTo.latitude) rawFrom to rawTo
-            else rawTo to rawFrom
-
-        val brg = bearing(from, to)
-        val perpendicular = brg + (90 * side)
-
-        MapSegment(
-            from = rawFrom.offsetMeters(offsetMeters, perpendicular),
-            to = rawTo.offsetMeters(offsetMeters, perpendicular),
-            lineColor = color
+    if (offsetMeters == 0.0) {
+        return MapSegment(
+            from = rawFrom,
+            to = rawTo,
+            lineColor = color,
         )
     }
+
+    val (from, to) =
+        if (rawFrom.latitude < rawTo.latitude) rawFrom to rawTo
+        else rawTo to rawFrom
+
+    val brg = bearing(from, to)
+    val perpendicular = brg + (90 * side)
+
+    return MapSegment(
+        from = rawFrom.offsetMeters(offsetMeters, perpendicular),
+        to = rawTo.offsetMeters(offsetMeters, perpendicular),
+        lineColor = color,
+    )
+}
 
 
 fun GeoPoint.offset(latOffset: Double, lonOffset: Double) =
@@ -430,6 +454,8 @@ fun MapView(
         }
         else -> null
     }
+
+    var showNeighborDiscoveryList by remember { mutableStateOf(false) }
 
     // UI Elements
     var cacheEstimate by remember { mutableStateOf("") }
@@ -513,6 +539,12 @@ fun MapView(
         is MapMode.Normal -> nodes
         is MapMode.Traceroute -> {
             (mode.trace.traceForwardList + mode.trace.traceBackList)
+                .distinctBy { it.num }
+        }
+        is MapMode.NeighborDiscovery -> {
+            (listOf(mode.discovery.origin) + mode.discovery.discovered.filter {
+                it.validPosition != null || it.isValidNodeLite()
+            })
                 .distinctBy { it.num }
         }
     }
@@ -665,6 +697,8 @@ fun MapView(
     }
 
     LaunchedEffect(mapMode) {
+        showNeighborDiscoveryList = false
+
         when (val mode = mapMode) {
             is MapMode.Traceroute -> {
                 map.drawTraceroute(mode.trace)
@@ -689,6 +723,24 @@ fun MapView(
                     map.zoomToBoundingBox(
                         BoundingBox.fromGeoPoints(points),
                         true
+                    )
+                }
+            }
+
+            is MapMode.NeighborDiscovery -> {
+                map.drawNeighborDiscovery(mode.discovery)
+
+                val points = mode.discovery.links.flatMap { link ->
+                    listOfNotNull(
+                        link.origin.toGeoPointOrNull(),
+                        link.discovered.toGeoPointOrNull(),
+                    )
+                }
+
+                if (points.isNotEmpty()) {
+                    map.zoomToBoundingBox(
+                        BoundingBox.fromGeoPoints(points),
+                        true,
                     )
                 }
             }
@@ -740,7 +792,7 @@ fun MapView(
 
         var wpts = onWaypointChanged(waypoints.values)
 
-        if(mapMode is MapMode.Traceroute){
+        if(mapMode is MapMode.Traceroute || mapMode is MapMode.NeighborDiscovery){
             wpts = emptyList()
         }
 
@@ -893,6 +945,15 @@ fun MapView(
                 )
             }
 
+            if (mapMode is MapMode.NeighborDiscovery && showNeighborDiscoveryList) {
+                NeighborDiscoveryDialog(
+                    discovery = (mapMode as MapMode.NeighborDiscovery).discovery.source,
+                    onDismiss = {
+                        showNeighborDiscoveryList = false
+                    },
+                )
+            }
+
             if (downloadRegionBoundingBox != null) CacheLayout(
                 cacheEstimate = cacheEstimate,
                 onExecuteJob = { startDownload() },
@@ -961,6 +1022,25 @@ fun MapView(
                         contentDescription = "Show Traceroute",
                     )
 
+                }
+
+                if (mapMode is MapMode.NeighborDiscovery) {
+                    MapButton(
+                        icon = Icons.Default.Clear,
+                        onClick = {
+                            showNeighborDiscoveryList = false
+                            model.exitNeighborDiscoveryMode()
+                        },
+                        contentDescription = "Clear Neighbor Discovery",
+                    )
+
+                    MapButton(
+                        icon = Icons.Default.People,
+                        onClick = {
+                            showNeighborDiscoveryList = !showNeighborDiscoveryList
+                        },
+                        contentDescription = "Show Neighbor Discovery",
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
+++ b/app/src/main/java/com/geeksville/mesh/ui/message/Message.kt
@@ -396,6 +396,7 @@ internal fun MessageScreen(
                     is NodeMenuAction.RequestUserInfo -> viewModel.requestUserInfo(action.node.num)
                     is NodeMenuAction.RequestPosition -> viewModel.requestPosition(action.node.num)
                     is NodeMenuAction.TraceRoute -> viewModel.requestTraceroute(action.node.num)
+                    is NodeMenuAction.NeighborDiscovery -> viewModel.requestNeighborDiscovery(action.node.num)
                     is NodeMenuAction.MoreDetails -> navigateToNodeDetails(action.node.num)
                     is NodeMenuAction.FavoriteNode -> viewModel.handleFavorite(action.node)
                     is NodeMenuAction.RequestDeviceMetadata -> viewModel.requestDeviceMetadata(action.node)

--- a/app/src/main/java/com/geeksville/mesh/util/AppUtil.kt
+++ b/app/src/main/java/com/geeksville/mesh/util/AppUtil.kt
@@ -2,6 +2,7 @@ package com.geeksville.mesh.util
 
 import android.content.Context
 import android.graphics.Color
+import androidx.compose.ui.graphics.Color as ComposeColor
 import com.geeksville.mesh.android.BuildUtils.errormsg
 import com.geeksville.mesh.model.DeviceHardware
 import com.geeksville.mesh.model.DeviceHardwareDto
@@ -21,6 +22,13 @@ import org.meshtastic.proto.MeshProtos.MeshPacket
 import org.meshtastic.proto.Portnums
 
 object AppUtil {
+
+    private const val CH_UTIL_GOOD_THRESHOLD = 25f
+    private const val CH_UTIL_FAIR_THRESHOLD = 50f
+    private const val AIR_UTIL_GOOD_THRESHOLD = 3f
+    private const val AIR_UTIL_FAIR_THRESHOLD = 5f
+    private const val AIR_UTIL_BAD_THRESHOLD = 7f
+    private const val AIR_UTIL_REALLY_BAD_THRESHOLD = 10f
 
     private val jsonParser: Json = Json {
         ignoreUnknownKeys = true
@@ -186,6 +194,20 @@ object AppUtil {
             in 30..59  -> Quality.BAD.color
             else       -> Quality.REALLY_BAD.color
         }
+    }
+
+    fun channelUtilizationColor(value: Float): ComposeColor = when {
+        value < CH_UTIL_GOOD_THRESHOLD -> Quality.GOOD.color
+        value < CH_UTIL_FAIR_THRESHOLD -> Quality.FAIR.color
+        else -> Quality.BAD.color
+    }
+
+    fun airUtilTxColor(value: Float): ComposeColor = when {
+        value < AIR_UTIL_GOOD_THRESHOLD -> Quality.GOOD.color
+        value < AIR_UTIL_FAIR_THRESHOLD -> Quality.FAIR.color
+        value < AIR_UTIL_BAD_THRESHOLD -> Quality.BAD.color
+        value < AIR_UTIL_REALLY_BAD_THRESHOLD -> Quality.REALLY_BAD.color
+        else -> Quality.REALLY_BAD.color
     }
 
     fun hexIdToNodeNum(hexId: String): Int {

--- a/app/src/main/res/layout/activity_advanced_settings.xml
+++ b/app/src/main/res/layout/activity_advanced_settings.xml
@@ -303,6 +303,64 @@
             app:layout_constraintTop_toBottomOf="@+id/useCompressionDesc"
             tools:ignore="HardcodedText,UseSwitchCompatOrMaterialXml" />
 
+        <TextView
+            android:id="@+id/showAirUtilChUtilTitle"
+            android:layout_width="220dp"
+            android:layout_height="22dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="20dp"
+            android:text="AIRUTIL / CHUTIL DETAILS"
+            android:textColor="@color/colorAnnotation"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/useCompressionSwitch"
+            tools:ignore="HardcodedText" />
+
+        <TextView
+            android:id="@+id/showAirUtilChUtilDesc"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:text="Shows Channel Utilization and Air Utilization in node details. By default this applies only to infrastructure nodes: CLIENT_BASE, ROUTER and ROUTER_LATE."
+            android:textSize="13sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/showAirUtilChUtilTitle"
+            tools:ignore="HardcodedText" />
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/showAirUtilChUtilSwitch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="Show AirUtil/ChUtil  "
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/showAirUtilChUtilDesc"
+            tools:ignore="HardcodedText,UseSwitchCompatOrMaterialXml" />
+
+        <TextView
+            android:id="@+id/showAirUtilChUtilAllNodesDesc"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:text="Extend this visualization to all nodes, not only infrastructure ones."
+            android:textSize="13sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/showAirUtilChUtilSwitch"
+            tools:ignore="HardcodedText" />
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/showAirUtilChUtilAllNodesSwitch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="Show on All Nodes  "
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/showAirUtilChUtilAllNodesDesc"
+            tools:ignore="HardcodedText,UseSwitchCompatOrMaterialXml" />
+
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -333,7 +333,19 @@
     <string name="signal">Signal</string>
     <string name="signal_quality">Signal Quality</string>
     <string name="traceroute_log">Traceroute Log</string>
+    <string name="neighbor_discovery">Neighbor Discovery</string>
+    <string name="neighbor_discovery_log">Neighbor Discovery Log</string>
+    <string name="neighbor_discovery_no_neighbors">No neighbors discovered</string>
+    <string name="neighbor_discovery_cannot_draw_map">Cannot draw Neighbor Discovery map!</string>
+    <string name="neighbor_discovery_request_gps_prompt">No discovered nodes with GPS available for map. Would you like to try retrieving GPS locations?</string>
+    <string name="neighbor_discovery_requesting_gps">Requesting GPS locations for Neighbor Discovery nodes</string>
+    <string name="view_on_map">View on Map</string>
+    <string name="view_on_list">View on List</string>
     <string name="traceroute_direct">Direct</string>
+    <plurals name="neighbor_discovery_nodes">
+        <item quantity="one">%d node discovered</item>
+        <item quantity="other">%d nodes discovered</item>
+    </plurals>
     <plurals name="traceroute_hops">
         <item quantity="one">1 hop</item>
         <item quantity="other">%d hops</item>


### PR DESCRIPTION
# Summary
This PR combines three related improvements to node discovery and relay telemetry UX:

- add the Neighbor Discovery workflow end-to-end, including response handling, history UI, and map fallback
- add Advanced Settings controls to expose AirUtil and ChUtil in node details for infrastructure nodes or for all nodes
- refine the relay card by introducing GRC (Gateway Related Confidence) as a clearer replacement for Closest Relay Confidence, and by surfacing relay-side SNR, RSSI, ChUtil, and AirUtil with dedicated badge thresholds

# Commit Order And Context
- `de358a1` introduces the Neighbor Discovery workflow and map fallback
- `83d8292` adds Advanced Settings controls for AirUtil and ChUtil visibility in node details
- `0cde79d` builds on that telemetry visibility work and introduces GRC (Gateway Related Confidence), plus the updated relay badge layout and AirUtil color scale

# What Changed
- add Neighbor Discovery request, parsing, state propagation, and UI integration across node actions, logs, dialogs, and map fallback flows
- expose AirUtil and ChUtil in node details with settings that can target infrastructure nodes only or all nodes
- update the relay info box layout to use GRC and show relay metrics on dedicated badges
- keep GRC color mapping aligned with the existing `AppUtil.relayNodePacketLabelColor()` thresholds
- apply a dedicated AirUtil badge scale:
  - `< 3%`: `Quality.GOOD.color`
  - `< 5%`: `Quality.FAIR.color`
  - `< 7%`: `Quality.BAD.color`
  - `< 10%`: `Quality.REALLY_BAD.color`
  
  # Validation
- `./gradlew assembleFdroidDebug --no-daemon --console=plain`
- installed the generated fdroid debug APK on the external device `RZCW6012J1M`
- verified app launch without bootstrap crashes during the relay card iterations